### PR TITLE
Updated Deep Moor data link

### DIFF
--- a/cc/01_parse_weather-data/14_get/main.go
+++ b/cc/01_parse_weather-data/14_get/main.go
@@ -8,7 +8,9 @@ import (
 )
 
 func main() {
-	res, err := http.Get("http://lpo.dt.navy.mil/data/DM/Environmental_Data_Deep_Moor_2015.txt")
+	// This url used to be at: http://lpo.dt.navy.mil/data/DM/Environmental_Data_Deep_Moor_2015.txt
+	// but has since been discontinued, the below url points to the source repository
+	res, err := http.Get("https://raw.githubusercontent.com/GoesToEleven/lynda/master/cc/01_parse_weather-data/Environmental_Data_Deep_Moor_2015.txt")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cc/01_parse_weather-data/15_get/main.go
+++ b/cc/01_parse_weather-data/15_get/main.go
@@ -10,7 +10,9 @@ import (
 )
 
 func main() {
-	res, err := http.Get("http://lpo.dt.navy.mil/data/DM/Environmental_Data_Deep_Moor_2015.txt")
+	// This url used to be at: http://lpo.dt.navy.mil/data/DM/Environmental_Data_Deep_Moor_2015.txt
+	// but has since been discontinued, the below url points to the source repository
+	res, err := http.Get("https://raw.githubusercontent.com/GoesToEleven/lynda/master/cc/01_parse_weather-data/Environmental_Data_Deep_Moor_2015.txt")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cc/01_parse_weather-data/16_error-handling_finished/main.go
+++ b/cc/01_parse_weather-data/16_error-handling_finished/main.go
@@ -10,7 +10,9 @@ import (
 )
 
 func main() {
-	res, err := http.Get("http://lpo.dt.navy.mil/data/DM/Environmental_Data_Deep_Moor_2015.txt")
+	// This url used to be at: http://lpo.dt.navy.mil/data/DM/Environmental_Data_Deep_Moor_2015.txt
+	// but has since been discontinued, the below url points to the source repository
+	res, err := http.Get("https://raw.githubusercontent.com/GoesToEleven/lynda/master/cc/01_parse_weather-data/Environmental_Data_Deep_Moor_2015.txt")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Updated the link for the Deep Moor data to point to [this repo](https://raw.githubusercontent.com/GoesToEleven/lynda/master/cc/01_parse_weather-data/Environmental_Data_Deep_Moor_2015.txt) instead of the original [lpo.dt.navy.mil](http://lpo.dt.navy.mil/data/DM/Environmental_Data_Deep_Moor_2015.txt)