### PR TITLE
Fix Weather Data Links

### DIFF
--- a/cc/01_parse_weather-data/14_get/main.go
+++ b/cc/01_parse_weather-data/14_get/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	res, err := http.Get("http://lpo.dt.navy.mil/data/DM/Environmental_Data_Deep_Moor_2015.txt")
+	res, err := http.Get("https://raw.githubusercontent.com/lyndadotcom/LPO_weatherdata/master/Environmental_Data_Deep_Moor_2015.txt")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cc/01_parse_weather-data/15_get/main.go
+++ b/cc/01_parse_weather-data/15_get/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	res, err := http.Get("http://lpo.dt.navy.mil/data/DM/Environmental_Data_Deep_Moor_2015.txt")
+	res, err := http.Get("https://raw.githubusercontent.com/lyndadotcom/LPO_weatherdata/master/Environmental_Data_Deep_Moor_2015.txt")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cc/01_parse_weather-data/16_error-handling_finished/main.go
+++ b/cc/01_parse_weather-data/16_error-handling_finished/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	res, err := http.Get("http://lpo.dt.navy.mil/data/DM/Environmental_Data_Deep_Moor_2015.txt")
+	res, err := http.Get("https://raw.githubusercontent.com/lyndadotcom/LPO_weatherdata/master/Environmental_Data_Deep_Moor_2015.txt")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The LPO Weather Data website has changed its structure such that the
links in this project that attempt to download the data no longer
function. Lynda.com have provided a github hosted copy of the data as
a replacement. This change moves references to the old site to the new
copy so that exercises can be completed.